### PR TITLE
added cloth-config to the mods.toml to get a proper message when missing

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -61,4 +61,4 @@ modId = "cloth_config"
 mandatory = true
 versionRange = "[8.2.88,)"
 ordering = "NONE"
-side = "BOTH"
+side = "CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -56,3 +56,9 @@ mandatory = true
 versionRange = "[1.19.2,1.20)"
 ordering = "NONE"
 side = "BOTH"
+[[dependencies.auditory]]
+modId = "cloth_config"
+mandatory = true
+versionRange = "[8.2.88,)"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
One important notice: Please add cloth-config as a dependency for both forge versions (on CurseForge) since it's not directly included in the jar.

Please replace the old version on CurseForge with this one, since the one on CurseForge does not include my other PR https://github.com/Sydokiddo/auditory/pull/41 which you merged into your branch but not rebuild the jar with this state.